### PR TITLE
Update NUglify 1.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 These are the changes to each version that has been released
 on the official Visual Studio extension gallery
 
+## 5.3
+
+- [x] NUglify got updated to 1.20.3
+
 ## 5.2
 
 - [x] NUglify got updated to 1.20.2

--- a/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
+++ b/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
@@ -13,9 +13,9 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>5.2</AssemblyVersion>
-    <FileVersion>5.2</FileVersion>
-    <Version>5.2</Version>
+    <AssemblyVersion>5.3</AssemblyVersion>
+    <FileVersion>5.3</FileVersion>
+    <Version>5.3</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUglify" Version="1.20.2" />
+    <PackageReference Include="NUglify" Version="1.20.3" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 

--- a/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
+++ b/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
@@ -16,9 +16,9 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>5.2</AssemblyVersion>
-    <FileVersion>5.2</FileVersion>
-    <Version>5.2</Version>
+    <AssemblyVersion>5.3</AssemblyVersion>
+    <FileVersion>5.3</FileVersion>
+    <Version>5.3</Version>
     <PackageId>BundlerMinifierPlus.TagHelpers</PackageId>
   </PropertyGroup>
 

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -21,9 +21,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Authors>Mads Kristensen, salar2k</Authors>
     <Copyright>Copyright 2022</Copyright>
-    <AssemblyVersion>5.2</AssemblyVersion>
-    <FileVersion>5.2</FileVersion>
-    <Version>5.2</Version>
+    <AssemblyVersion>5.3</AssemblyVersion>
+    <FileVersion>5.3</FileVersion>
+    <Version>5.3</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" PrivateAssets="All" />
-    <PackageReference Include="NUglify" Version="1.20.2" PrivateAssets="All" />
+    <PackageReference Include="NUglify" Version="1.20.3" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/src/BundlerMinifierTest/BundlerMinifierTest.csproj
+++ b/src/BundlerMinifierTest/BundlerMinifierTest.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <None Remove="artifacts\file5.js" />
+    <None Remove="artifacts\file6.js" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BundlerMinifierTest/BundlerTest.cs
+++ b/src/BundlerMinifierTest/BundlerTest.cs
@@ -41,6 +41,7 @@ namespace BundlerMinifierTest
             File.Delete("../../../artifacts/file4.min.html");
             File.Delete("../../../artifacts/test7.min.js");
             File.Delete("../../../artifacts/test8.min.js");
+            File.Delete("../../../artifacts/test10.min.js");
         }
 
         [TestMethod]
@@ -220,6 +221,16 @@ namespace BundlerMinifierTest
             string jsResult = File.ReadAllText("../../../artifacts/test9.min.js");
 
             Assert.AreEqual("function r(n,t){return n**t}let x=2**5.1,y=3**x,z=2**81,p=21;", jsResult);
+        }
+
+        [TestMethod]
+        public void DuplicatePropertyNames()
+        {
+            _processor.Process(TEST_BUNDLE.Replace("test1", "test10"));
+
+            string jsResult = File.ReadAllText("../../../artifacts/test10.min.js");
+
+            Assert.AreEqual("\"use strict\";const config={...Man.get(target),...Man.get(this),...!1,...!1};", jsResult);
         }
     }
 }

--- a/src/BundlerMinifierTest/artifacts/file6.js
+++ b/src/BundlerMinifierTest/artifacts/file6.js
@@ -1,0 +1,7 @@
+﻿"use strict";
+const config = {
+	...Man.get(target),
+	...Man.get(this),
+	...(true ? false : true),
+	...(false ? true : false)
+};

--- a/src/BundlerMinifierTest/artifacts/test10.json
+++ b/src/BundlerMinifierTest/artifacts/test10.json
@@ -1,0 +1,12 @@
+﻿[
+	{
+		"outputFileName": "test10.min.js",
+		"inputFiles": [
+			"file6.js"
+		],
+		"minify": {
+			"enabled": true
+		},
+		"includeInProject": true
+	}
+]

--- a/src/BundlerMinifierVsix/BundlerMinifierVsix.csproj
+++ b/src/BundlerMinifierVsix/BundlerMinifierVsix.csproj
@@ -216,7 +216,7 @@
       <Version>17.2.1</Version>
     </PackageReference>
     <PackageReference Include="NUglify">
-      <Version>1.20.2</Version>
+      <Version>1.20.3</Version>
     </PackageReference>
   </ItemGroup>
   <!-- end workaround -->


### PR DESCRIPTION
As per [1#issuecomment-1325834390](/salarcode/BundlerMinifierPlus/pull/1#issuecomment-1325834390)

New NUglify version [Release v1.20.3](https://github.com/trullock/NUglify/releases/tag/v1.20.3) fixes issues with bundling bootstrap 5.2.2 js. See trullock/NUglify#279

Turns out I didn't have to hijack the other PR since I had a decent roadmap of what changed to update NUglify from the last commit. I can own my very own PR, thank you very much =) Hope it is all up to standards as I basically just painted by numbers and still have no idea where the actual package builds to.

Changes made:

Updated NUglify dependency 1.20.3
Upgraded projects to 5.3
Added unit test for duplicate property names (the bootstrap exposed bug)
Appended new changelog entry

Please release a new version so we can bundle bootstrap again.

nJoy!