### PR TITLE
Upgrade NUglify to 1.21.8 (+Test, version upgrade to 5.4 & copyright update to 2024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 These are the changes to each version that has been released
 on the official Visual Studio extension gallery
 
+## 5.4
+
+- [x] NUglify got updated to 1.21.8
+
 ## 5.3
 
 - [x] NUglify got updated to 1.20.3

--- a/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
+++ b/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
@@ -13,9 +13,9 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>5.3</AssemblyVersion>
-    <FileVersion>5.3</FileVersion>
-    <Version>5.3</Version>
+    <AssemblyVersion>5.4</AssemblyVersion>
+    <FileVersion>5.4</FileVersion>
+    <Version>5.4</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUglify" Version="1.20.3" />
+    <PackageReference Include="NUglify" Version="1.21.8" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 

--- a/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
+++ b/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
@@ -6,7 +6,7 @@
     <Authors>Gérald Barré, Mads Kristensen, RockstarDev, salar2k</Authors>
     <Product>Bundler &amp; Minifier TagHelpers</Product>
     <PackageLicenseUrl>https://github.com/salarcode/BundlerMinifierPlus/blob/master/LICENSE</PackageLicenseUrl>
-    <Copyright>Copyright 2022</Copyright>
+    <Copyright>Copyright 2024</Copyright>
     <PackageIconUrl>https://raw.githubusercontent.com/madskristensen/BundlerMinifier/master/src/BundlerMinifierVsix/Resources/icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/salarcode/BundlerMinifierPlus</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -16,9 +16,9 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>5.3</AssemblyVersion>
-    <FileVersion>5.3</FileVersion>
-    <Version>5.3</Version>
+    <AssemblyVersion>5.4</AssemblyVersion>
+    <FileVersion>5.4</FileVersion>
+    <Version>5.4</Version>
     <PackageId>BundlerMinifierPlus.TagHelpers</PackageId>
   </PropertyGroup>
 

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -20,10 +20,10 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Authors>Mads Kristensen, salar2k</Authors>
-    <Copyright>Copyright 2022</Copyright>
-    <AssemblyVersion>5.3</AssemblyVersion>
-    <FileVersion>5.3</FileVersion>
-    <Version>5.3</Version>
+    <Copyright>Copyright 2024</Copyright>
+    <AssemblyVersion>5.4</AssemblyVersion>
+    <FileVersion>5.4</FileVersion>
+    <Version>5.4</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" PrivateAssets="All" />
-    <PackageReference Include="NUglify" Version="1.20.3" PrivateAssets="All" />
+    <PackageReference Include="NUglify" Version="1.21.8" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/src/BundlerMinifierTest/BundlerTest.cs
+++ b/src/BundlerMinifierTest/BundlerTest.cs
@@ -110,7 +110,7 @@ namespace BundlerMinifierTest
 
             // CSS
             string cssResult = File.ReadAllText(new FileInfo("../../../artifacts/foo.min.css").FullName);
-            Assert.AreEqual("body{background:url('/test.png')}body{display:block}:root{--bb-width-test:}body{background:url(test2/image.png?foo=hat)}", cssResult);
+            Assert.AreEqual("body{background:url('/test.png')}body{display:block}:root{--bb-width-test:}body:nth-child(1 of .test){background-color:#000}body{background:url(test2/image.png?foo=hat)}", cssResult);
 
             // HTML
             string htmlResult = File.ReadAllText("../../../artifacts/foo.min.html");

--- a/src/BundlerMinifierTest/artifacts/file2.css
+++ b/src/BundlerMinifierTest/artifacts/file2.css
@@ -2,3 +2,6 @@
 :root{
     --bb-width-test: ;
 } 
+body:nth-child(1 of .test) {
+    background-color: black;
+}


### PR DESCRIPTION
Changes:
- Upgrades to [NUglify v1.28.1](https://github.com/trullock/NUglify/releases/tag/v1.21.8)
- Adds the usage of the CSS ``of`` keyword to the tests since it's part of what NUglify v1.28.1 fixes
- Updated the copyright in the assemblies from 2022 to 2024

Did everything the same way as #2 did.

Please merge and release a new version NuGet :)

Have a nice day